### PR TITLE
Add support for debug option

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ module.exports = (context, options = {}) => {
     ignoreBrowserslistConfig = modern,
     configPath,
     forceAllTransforms,
-    decoratorsLegacy
+    decoratorsLegacy,
+    debug = false
   } = options
 
   let targets = options.targets
@@ -79,7 +80,8 @@ module.exports = (context, options = {}) => {
       useBuiltIns,
       forceAllTransforms,
       ignoreBrowserslistConfig,
-      exclude: polyfills
+      exclude: polyfills,
+      debug
     }
   ])
 


### PR DESCRIPTION
@babel/preset-env supports a `debug` option which is very useful during development, so we should support it as well